### PR TITLE
feat: only do each unique transform once

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +78,33 @@ jobs:
             --benchmark-compare='*_main' \
             --benchmark-compare-fail=mean:20% \
             -v
+
+      - name: Post benchmark comparison comment
+        if: >
+          github.event_name == 'pull_request' &&
+          steps.baseline-check.outputs.has_baseline == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run python scripts/format_benchmark_comparison.py \
+            --baseline '.benchmarks/**/*_main.json' \
+            --pr '.benchmarks/**/*_pr-*.json' \
+            > benchmark_report.md
+
+          PR=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq '.[] | select(.body | startswith("<!-- lazycogs-benchmark-comparison -->")) | .id' \
+            | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              -X PATCH -f body="$(cat benchmark_report.md)"
+          else
+            gh api "repos/$REPO/issues/$PR/comments" \
+              -X POST -f body="$(cat benchmark_report.md)"
+          fi
 
       - name: Run benchmarks (PR — no baseline, informational only)
         if: >

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -73,7 +73,7 @@ jobs:
             --benchmark-enable \
             --benchmark-save=pr-${{ github.sha }} \
             --benchmark-storage=.benchmarks \
-            --benchmark-compare=main \
+            --benchmark-compare='*_main' \
             --benchmark-compare-fail=mean:20% \
             -v
 

--- a/scripts/format_benchmark_comparison.py
+++ b/scripts/format_benchmark_comparison.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Format a pytest-benchmark comparison as a GitHub-flavored markdown table.
+
+Usage:
+    uv run python scripts/format_benchmark_comparison.py \
+        --baseline '.benchmarks/**/*_main.json' \
+        --pr '.benchmarks/**/*_pr-*.json'
+"""
+
+import argparse
+import glob
+import json
+import logging
+import sys
+from pathlib import Path
+
+
+def find_file(pattern: str) -> Path:
+    """Find the most recently modified file matching the given glob pattern."""
+    matches = glob.glob(pattern, recursive=True)
+    if not matches:
+        raise FileNotFoundError(f"No files match: {pattern!r}")
+    return max((Path(m) for m in matches), key=lambda p: p.stat().st_mtime)
+
+
+def load_benchmarks(path: Path) -> dict[str, dict]:
+    """Load benchmark stats keyed by test name from a pytest-benchmark JSON file."""
+    with path.open() as f:
+        data = json.load(f)
+    return {b["name"]: b["stats"] for b in data["benchmarks"]}
+
+
+def _ms(seconds: float) -> str:
+    """Format a duration in seconds as a millisecond string."""
+    return f"{seconds * 1000:.1f}"
+
+
+def generate_report(baseline: dict[str, dict], pr: dict[str, dict]) -> str:
+    """Generate a markdown benchmark comparison table."""
+    rows = []
+    for name in sorted(baseline):
+        if name not in pr:
+            continue
+        base_mean = baseline[name]["mean"]
+        pr_mean = pr[name]["mean"]
+        pct = (pr_mean - base_mean) / base_mean * 100
+        sign = "+" if pct >= 0 else ""
+        flag = " :warning:" if pct > 10 else ""
+        rows.append(
+            f"| `{name}` | {_ms(base_mean)} | {_ms(pr_mean)} | {sign}{pct:.1f}%{flag} |"
+        )
+
+    table = "\n".join(
+        [
+            "| Test | Baseline (ms) | PR (ms) | Change |",
+            "|------|:-------------:|:-------:|-------:|",
+            *rows,
+        ]
+    )
+    return (
+        f"<!-- lazycogs-benchmark-comparison -->\n## Benchmark Comparison\n\n{table}\n"
+    )
+
+
+def main() -> None:
+    """Entry point."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline", required=True, help="Glob pattern for the baseline JSON"
+    )
+    parser.add_argument("--pr", required=True, help="Glob pattern for the PR JSON")
+    args = parser.parse_args()
+
+    try:
+        baseline_path = find_file(args.baseline)
+        pr_path = find_file(args.pr)
+    except FileNotFoundError as e:
+        logging.error("%s", e)
+        sys.exit(1)
+
+    logging.info("Baseline: %s", baseline_path)
+    logging.info("PR:       %s", pr_path)
+
+    print(generate_report(load_benchmarks(baseline_path), load_benchmarks(pr_path)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lazycogs/_backend.py
+++ b/src/lazycogs/_backend.py
@@ -473,6 +473,10 @@ class MultiBandStacBackendArray(BackendArray):
             dtype=self.dtype,
         )
 
+        # Shared across all time steps: source tiles at the same grid position
+        # (identical src_transform + src_crs) reuse the same WarpMap.
+        warp_cache: dict = {}
+
         for i, t_idx in enumerate(time_indices):
             date = ref.dates[t_idx]
 
@@ -510,6 +514,7 @@ class MultiBandStacBackendArray(BackendArray):
                     mosaic_method_cls=ref.mosaic_method_cls,
                     store=ref.store,
                     max_concurrent_reads=ref.max_concurrent_reads,
+                    warp_cache=warp_cache,
                 )
             )
             logger.debug(

--- a/src/lazycogs/_backend.py
+++ b/src/lazycogs/_backend.py
@@ -17,7 +17,7 @@ from xarray.core import indexing
 
 import rustac
 
-from lazycogs._chunk_reader import async_mosaic_chunk
+from lazycogs._chunk_reader import async_mosaic_chunk, async_mosaic_chunk_multiband
 from lazycogs._mosaic_methods import MosaicMethodBase
 
 logger = logging.getLogger(__name__)
@@ -394,9 +394,10 @@ class MultiBandStacBackendArray(BackendArray):
     def _raw_getitem(self, key: tuple[Any, ...]) -> np.ndarray:
         """Materialise the chunk identified by ``key``.
 
-        Delegates spatial/temporal I/O to each per-band
-        :class:`StacBackendArray`, then stacks the results along the band
-        axis.
+        Reads all selected bands together per time step via
+        :func:`~lazycogs._chunk_reader.async_mosaic_chunk_multiband`, issuing
+        a single ``rustac.search_sync`` query per time step and sharing
+        reprojection warp maps across bands that have identical source geometry.
 
         Args:
             key: A tuple of ``int | slice`` objects for the
@@ -408,6 +409,7 @@ class MultiBandStacBackendArray(BackendArray):
         """
         band_key, time_key, y_key, x_key = key
 
+        # -- Band dimension --------------------------------------------------
         n_bands = len(self.band_arrays)
         if isinstance(band_key, (int, np.integer)):
             band_indices: list[int] = [int(band_key)]
@@ -419,11 +421,123 @@ class MultiBandStacBackendArray(BackendArray):
             band_indices = list(range(start, stop, step))
             squeeze_band = False
 
-        results = [
-            self.band_arrays[b]._raw_getitem((time_key, y_key, x_key))
-            for b in band_indices
-        ]
+        selected_band_names = [self.band_names[b] for b in band_indices]
+        ref = self.band_arrays[band_indices[0]]
 
+        # -- Time dimension --------------------------------------------------
+        n_dates = len(ref.dates)
+        if isinstance(time_key, (int, np.integer)):
+            time_indices: list[int] = [int(time_key)]
+            squeeze_time = True
+        else:
+            t_start = time_key.start if time_key.start is not None else 0
+            t_stop = time_key.stop if time_key.stop is not None else n_dates
+            t_step = time_key.step if time_key.step is not None else 1
+            time_indices = list(range(t_start, t_stop, t_step))
+            squeeze_time = False
+
+        # -- Spatial dimensions ----------------------------------------------
+        if isinstance(y_key, (int, np.integer)):
+            yi = int(y_key)
+            y_key = slice(yi, yi + 1)
+            squeeze_y = True
+        else:
+            squeeze_y = False
+
+        if isinstance(x_key, (int, np.integer)):
+            xi = int(x_key)
+            x_key = slice(xi, xi + 1)
+            squeeze_x = True
+        else:
+            squeeze_x = False
+
+        y_start_logical = y_key.start if y_key.start is not None else 0
+        y_stop_logical = y_key.stop if y_key.stop is not None else ref.dst_height
+        x_start = x_key.start if x_key.start is not None else 0
+        x_stop = x_key.stop if x_key.stop is not None else ref.dst_width
+
+        y_start_physical = ref.dst_height - y_stop_logical
+        y_stop_physical = ref.dst_height - y_start_logical
+
+        chunk_height = y_stop_physical - y_start_physical
+        chunk_width = x_stop - x_start
+
+        chunk_affine = ref.dst_affine * Affine.translation(x_start, y_start_physical)
+        chunk_bbox_4326 = ref._chunk_bbox_4326(chunk_affine, chunk_width, chunk_height)
+
+        # -- Read all bands together per time step ---------------------------
+        fill = ref.nodata if ref.nodata is not None else 0
+        result = np.full(
+            (len(band_indices), len(time_indices), chunk_height, chunk_width),
+            fill,
+            dtype=self.dtype,
+        )
+
+        for i, t_idx in enumerate(time_indices):
+            date = ref.dates[t_idx]
+
+            t0 = time.perf_counter()
+            items = rustac.search_sync(
+                ref.parquet_path,
+                bbox=chunk_bbox_4326,
+                datetime=date,
+                use_duckdb=True,
+                sortby=ref.sort_by,
+                filter=ref.filter,
+                ids=ref.ids,
+            )
+            logger.debug(
+                "rustac.search_sync bands=%r date=%s returned %d items in %.3fs",
+                selected_band_names,
+                date,
+                len(items),
+                time.perf_counter() - t0,
+            )
+
+            if not items:
+                continue
+
+            t0 = time.perf_counter()
+            chunk_data = _run_coroutine(
+                async_mosaic_chunk_multiband(
+                    items=items,
+                    bands=selected_band_names,
+                    chunk_affine=chunk_affine,
+                    dst_crs=ref.dst_crs,
+                    chunk_width=chunk_width,
+                    chunk_height=chunk_height,
+                    nodata=ref.nodata,
+                    mosaic_method_cls=ref.mosaic_method_cls,
+                    store=ref.store,
+                    max_concurrent_reads=ref.max_concurrent_reads,
+                )
+            )
+            logger.debug(
+                "async_mosaic_chunk_multiband bands=%r date=%s (%d items, %dx%d px) took %.3fs",
+                selected_band_names,
+                date,
+                len(items),
+                chunk_width,
+                chunk_height,
+                time.perf_counter() - t0,
+            )
+
+            for bi, band in enumerate(selected_band_names):
+                arr = chunk_data[band]
+                result[bi, i] = arr[0] if arr.ndim == 3 else arr
+
+        # Physical data is top-down; flip to ascending y order for xarray.
+        result = result[:, :, ::-1, :]
+
+        # result shape: (n_selected_bands, n_time, chunk_height, chunk_width)
+        # Apply squeezes in axis order: time (axis 1), band (axis 0), y (-2), x (-1).
+        out: np.ndarray = result  # type: ignore[assignment]
+        if squeeze_time:
+            out = out[:, 0, :, :]
         if squeeze_band:
-            return results[0]
-        return np.stack(results, axis=0)
+            out = out[0]
+        if squeeze_y:
+            out = np.take(out, 0, axis=-2)
+        if squeeze_x:
+            out = out[..., 0]
+        return out

--- a/src/lazycogs/_chunk_reader.py
+++ b/src/lazycogs/_chunk_reader.py
@@ -14,7 +14,12 @@ from async_geotiff import GeoTIFF, Overview, Window
 from pyproj import CRS, Transformer
 
 from lazycogs._mosaic_methods import FirstMethod, MosaicMethodBase
-from lazycogs._reproject import reproject_array
+from lazycogs._reproject import (
+    WarpMap,
+    apply_warp_map,
+    compute_warp_map,
+    reproject_array,
+)
 from lazycogs._store import path_from_href, store_from_href
 
 if TYPE_CHECKING:
@@ -372,3 +377,348 @@ async def async_mosaic_chunk(
         return np.full((bands, chunk_height, chunk_width), fill, dtype=np.float32)
 
     return mosaic_method.data
+
+
+def _apply_bands_with_warp_cache(
+    band_rasters: list[tuple[str, object, CRS, float | None]],
+    dst_transform: Affine,
+    dst_crs: CRS,
+    dst_width: int,
+    dst_height: int,
+) -> dict[str, tuple[np.ndarray, float | None]]:
+    """Apply warp maps to multiple band rasters, reusing maps for identical geometries.
+
+    Maintains a local cache keyed on ``(tuple(raster.transform), src_crs.to_wkt())``.
+    Bands that share the same source CRS and window transform (the common case for
+    bands from the same STAC item) compute the warp map once and share it.  Bands
+    with different geometries each compute their own correct warp map.
+
+    This function is designed to run inside a thread executor — it is CPU-bound
+    and must not be called from the async event loop directly.
+
+    Args:
+        band_rasters: List of ``(band_name, raster, src_crs, effective_nodata)``
+            tuples.  ``raster`` must have ``.transform`` (Affine) and ``.data``
+            (ndarray of shape ``(bands, h, w)``) attributes.
+        dst_transform: Affine transform of the destination grid.
+        dst_crs: CRS of the destination grid.
+        dst_width: Width of the destination grid in pixels.
+        dst_height: Height of the destination grid in pixels.
+
+    Returns:
+        ``dict`` mapping band name to ``(reprojected_array, effective_nodata)``.
+
+    """
+    cache: dict[tuple[tuple[float, ...], str], WarpMap] = {}
+    results: dict[str, tuple[np.ndarray, float | None]] = {}
+
+    for band, raster, src_crs, effective_nodata in band_rasters:
+        cache_key = (tuple(raster.transform), src_crs.to_wkt())
+        if cache_key not in cache:
+            cache[cache_key] = compute_warp_map(
+                src_transform=raster.transform,
+                src_crs=src_crs,
+                dst_transform=dst_transform,
+                dst_crs=dst_crs,
+                dst_width=dst_width,
+                dst_height=dst_height,
+            )
+        results[band] = (
+            apply_warp_map(raster.data, cache[cache_key], effective_nodata),
+            effective_nodata,
+        )
+
+    return results
+
+
+async def _read_item_bands(
+    item: dict,
+    bands: list[str],
+    chunk_affine: Affine,
+    dst_crs: CRS,
+    chunk_width: int,
+    chunk_height: int,
+    nodata: float | None,
+    store: object | None = None,
+) -> dict[str, tuple[np.ndarray, float | None]] | None:
+    """Read and reproject multiple bands from one STAC item, sharing warp maps.
+
+    Opens all band COGs concurrently, computes per-band windows independently
+    (so bands with different native resolutions or extents are handled correctly),
+    reads all windows concurrently, then dispatches a single thread-executor call
+    that applies warp maps with caching: bands sharing the same source CRS and
+    window transform reuse the same warp map.
+
+    Args:
+        item: STAC item dict containing an ``assets`` key.
+        bands: Asset keys to read from this item.
+        chunk_affine: Affine transform of the destination chunk.
+        dst_crs: CRS of the destination chunk.
+        chunk_width: Width of the destination chunk in pixels.
+        chunk_height: Height of the destination chunk in pixels.
+        nodata: No-data fill value.  When ``None``, the value stored in the
+            COG header (``GeoTIFF.nodata``) is used if present.
+        store: Optional pre-configured obstore ``ObjectStore`` instance.
+
+    Returns:
+        ``dict`` mapping band name to ``(array, effective_nodata)`` where
+        *array* has shape ``(bands, chunk_height, chunk_width)``.  Returns
+        ``None`` if no requested band overlaps the chunk.
+
+    """
+    # Collect hrefs for all requested bands.
+    band_hrefs: dict[str, str] = {}
+    for band in bands:
+        asset = item.get("assets", {}).get(band)
+        if asset is not None:
+            band_hrefs[band] = asset["href"]
+
+    if not band_hrefs:
+        return None
+
+    # Open all COGs concurrently for metadata.
+    async def _open_band(band: str, href: str) -> tuple[str, object, object]:
+        if store is not None:
+            path = path_from_href(href)
+            geotiff = await GeoTIFF.open(path, store=store)
+            return band, geotiff, store
+        band_store, path = store_from_href(href)
+        geotiff = await GeoTIFF.open(path, store=band_store)
+        return band, geotiff, band_store
+
+    open_results = await asyncio.gather(
+        *[_open_band(b, h) for b, h in band_hrefs.items()]
+    )
+
+    # Per-band: select overview, compute window.
+    # Each band is handled independently so differing native resolutions or
+    # extents are handled correctly.
+    band_read_plan: list[tuple[str, object, object, Window, float | None]] = []
+    for band, geotiff, _ in open_results:
+        effective_nodata = nodata if nodata is not None else geotiff.nodata
+
+        target_res_native = abs(chunk_affine.a)
+        if not dst_crs.equals(geotiff.crs):
+            cx = chunk_affine.c + (chunk_width / 2) * chunk_affine.a
+            cy = chunk_affine.f + (chunk_height / 2) * chunk_affine.e
+            t = Transformer.from_crs(dst_crs, geotiff.crs, always_xy=True)
+            x0, y0 = t.transform(cx, cy)
+            x1, y1 = t.transform(cx + chunk_affine.a, cy)
+            target_res_native = abs(x1 - x0)
+
+        overview = _select_overview(geotiff, target_res_native)
+        reader = overview if overview is not None else geotiff
+
+        chunk_minx = chunk_affine.c
+        chunk_maxy = chunk_affine.f
+        chunk_maxx = chunk_minx + chunk_width * chunk_affine.a
+        chunk_miny = chunk_maxy + chunk_height * chunk_affine.e
+
+        if dst_crs.equals(geotiff.crs):
+            bbox_native = (chunk_minx, chunk_miny, chunk_maxx, chunk_maxy)
+        else:
+            t_to_src = Transformer.from_crs(dst_crs, geotiff.crs, always_xy=True)
+            xs, ys = t_to_src.transform(
+                [chunk_minx, chunk_maxx, chunk_minx, chunk_maxx],
+                [chunk_maxy, chunk_maxy, chunk_miny, chunk_miny],
+            )
+            bbox_native = (min(xs), min(ys), max(xs), max(ys))
+
+        window = _native_window(reader, bbox_native, reader.width, reader.height)
+        if window is None:
+            logger.debug(
+                "Item %s band %r does not overlap chunk; skipping.",
+                item.get("id"),
+                band,
+            )
+            continue
+
+        band_read_plan.append((band, geotiff, reader, window, effective_nodata))
+
+    if not band_read_plan:
+        return None
+
+    # Read all windows concurrently.
+    async def _read_band(
+        band: str, reader: object, window: Window
+    ) -> tuple[str, object]:
+        return band, await reader.read(window=window)
+
+    read_results = await asyncio.gather(
+        *[_read_band(b, r, w) for b, _, r, w, _ in band_read_plan]
+    )
+
+    effective_nodatas = {b: n for b, _, _, _, n in band_read_plan}
+    crss = {b: g.crs for b, g, _, _, _ in band_read_plan}
+
+    band_rasters = [
+        (band, raster, crss[band], effective_nodatas[band])
+        for band, raster in read_results
+    ]
+
+    # Compute warp maps and apply, sharing maps across bands with identical geometry.
+    loop = asyncio.get_running_loop()
+    results = await loop.run_in_executor(
+        None,
+        lambda: _apply_bands_with_warp_cache(
+            band_rasters,
+            chunk_affine,
+            dst_crs,
+            chunk_width,
+            chunk_height,
+        ),
+    )
+    return results
+
+
+async def async_mosaic_chunk_multiband(
+    items: list[dict],
+    bands: list[str],
+    chunk_affine: Affine,
+    dst_crs: CRS,
+    chunk_width: int,
+    chunk_height: int,
+    nodata: float | None = None,
+    mosaic_method_cls: type[MosaicMethodBase] | None = None,
+    store: object | None = None,
+    max_concurrent_reads: int = 32,
+) -> dict[str, np.ndarray]:
+    """Read, reproject, and mosaic multiple bands from a list of STAC items.
+
+    Multi-band variant of :func:`async_mosaic_chunk`.  Processes all requested
+    bands together per item so that bands sharing the same source geometry
+    compute the reprojection warp map only once (via
+    :func:`_apply_bands_with_warp_cache`).
+
+    Items are processed in batches of ``max_concurrent_reads``.  When all
+    per-band mosaic methods signal completion, remaining batches are skipped.
+
+    Args:
+        items: List of STAC item dicts to mosaic.  Processed in order.
+        bands: Asset keys identifying the bands to read from each item.
+        chunk_affine: Affine transform of the destination chunk.
+        dst_crs: CRS of the destination chunk.
+        chunk_width: Width of the destination chunk in pixels.
+        chunk_height: Height of the destination chunk in pixels.
+        nodata: No-data fill value.
+        mosaic_method_cls: Mosaic method class instantiated once per band.
+            Defaults to :class:`~lazycogs._mosaic_methods.FirstMethod`.
+        store: Optional pre-configured obstore ``ObjectStore`` instance.
+        max_concurrent_reads: Maximum number of COG reads to run concurrently.
+
+    Returns:
+        ``dict`` mapping each band name to an array of shape
+        ``(cog_bands, chunk_height, chunk_width)`` with dtype matching the
+        source COGs.
+
+    """
+    if mosaic_method_cls is None:
+        mosaic_method_cls = FirstMethod
+
+    logger.debug(
+        "async_mosaic_chunk_multiband bands=%r %dx%d px, %d items (max_concurrent_reads=%d)",
+        bands,
+        chunk_width,
+        chunk_height,
+        len(items),
+        max_concurrent_reads,
+    )
+
+    semaphore = asyncio.Semaphore(max_concurrent_reads)
+
+    async def _guarded(item: dict) -> dict[str, tuple[np.ndarray, float | None]] | None:
+        async with semaphore:
+            return await _read_item_bands(
+                item,
+                bands,
+                chunk_affine,
+                dst_crs,
+                chunk_width,
+                chunk_height,
+                nodata,
+                store=store,
+            )
+
+    batch_size = min(max_concurrent_reads, len(items))
+    estimated_peak_mb = (
+        batch_size * len(bands) * chunk_width * chunk_height * 4 / (1024**2)
+    )
+    if estimated_peak_mb > 500:
+        logger.warning(
+            "Estimated peak in-flight memory for bands=%r is ~%.0f MB "
+            "(%d concurrent reads × %d bands × %dx%d px). "
+            "Lower max_concurrent_reads or add spatial chunks to reduce memory use.",
+            bands,
+            estimated_peak_mb,
+            batch_size,
+            len(bands),
+            chunk_width,
+            chunk_height,
+        )
+
+    mosaic_methods: dict[str, MosaicMethodBase] = {
+        b: mosaic_method_cls() for b in bands
+    }
+
+    t0 = time.perf_counter()
+    done = False
+    items_read = 0
+    for batch_start in range(0, len(items), max_concurrent_reads):
+        batch = items[batch_start : batch_start + max_concurrent_reads]
+        batch_results = await asyncio.gather(
+            *[_guarded(item) for item in batch],
+            return_exceptions=True,
+        )
+        items_read += len(batch)
+
+        for j, result in enumerate(batch_results):
+            item_idx = batch_start + j
+            if isinstance(result, BaseException):
+                item_id = items[item_idx].get("id", "<unknown>")
+                logger.warning(
+                    "Failed to read bands %r from item %s: %s",
+                    bands,
+                    item_id,
+                    result,
+                    exc_info=result,
+                )
+                continue
+
+            if result is None:
+                continue
+
+            for band, (arr, effective_nodata) in result.items():
+                arr_mask: np.ndarray
+                if effective_nodata is not None:
+                    arr_mask = np.all(arr == effective_nodata, axis=0, keepdims=True)
+                    arr_mask = np.broadcast_to(arr_mask, arr.shape).copy()
+                else:
+                    arr_mask = np.zeros(arr.shape, dtype=bool)
+                mosaic_methods[band].feed(ma.MaskedArray(arr, mask=arr_mask))
+
+            if all(m.is_done for m in mosaic_methods.values()):
+                done = True
+                break
+
+        if done:
+            break
+
+    logger.debug(
+        "async_mosaic_chunk_multiband bands=%r read %d/%d items in %.3fs",
+        bands,
+        items_read,
+        len(items),
+        time.perf_counter() - t0,
+    )
+
+    fill = nodata if nodata is not None else 0
+    output: dict[str, np.ndarray] = {}
+    for band in bands:
+        method = mosaic_methods[band]
+        if method._mosaic is None:
+            output[band] = np.full(
+                (1, chunk_height, chunk_width), fill, dtype=np.float32
+            )
+        else:
+            output[band] = method.data
+    return output

--- a/src/lazycogs/_chunk_reader.py
+++ b/src/lazycogs/_chunk_reader.py
@@ -385,16 +385,21 @@ def _apply_bands_with_warp_cache(
     dst_crs: CRS,
     dst_width: int,
     dst_height: int,
+    warp_cache: dict[tuple[tuple[float, ...], str], WarpMap] | None = None,
 ) -> dict[str, tuple[np.ndarray, float | None]]:
     """Apply warp maps to multiple band rasters, reusing maps for identical geometries.
 
-    Maintains a local cache keyed on ``(tuple(raster.transform), src_crs.to_wkt())``.
-    Bands that share the same source CRS and window transform (the common case for
-    bands from the same STAC item) compute the warp map once and share it.  Bands
-    with different geometries each compute their own correct warp map.
+    Checks ``warp_cache`` (keyed on ``(tuple(raster.transform), src_crs.to_wkt())``)
+    before computing a new warp map.  When ``warp_cache`` is shared across calls
+    (e.g. across time steps in a single chunk read), warp maps for recurring tile
+    geometries are computed only once.  Bands with different geometries each get
+    their own correct warp map.
 
     This function is designed to run inside a thread executor — it is CPU-bound
-    and must not be called from the async event loop directly.
+    and must not be called from the async event loop directly.  When ``warp_cache``
+    is shared across concurrent executor calls, two threads may both compute the
+    same warp map before either stores it; this is safe because ``compute_warp_map``
+    is deterministic and the duplicate result is simply overwritten.
 
     Args:
         band_rasters: List of ``(band_name, raster, src_crs, effective_nodata)``
@@ -404,12 +409,16 @@ def _apply_bands_with_warp_cache(
         dst_crs: CRS of the destination grid.
         dst_width: Width of the destination grid in pixels.
         dst_height: Height of the destination grid in pixels.
+        warp_cache: Optional external cache shared across calls.  When ``None``
+            a fresh local dict is used (original per-item behaviour).
 
     Returns:
         ``dict`` mapping band name to ``(reprojected_array, effective_nodata)``.
 
     """
-    cache: dict[tuple[tuple[float, ...], str], WarpMap] = {}
+    cache: dict[tuple[tuple[float, ...], str], WarpMap] = (
+        warp_cache if warp_cache is not None else {}
+    )
     results: dict[str, tuple[np.ndarray, float | None]] = {}
 
     for band, raster, src_crs, effective_nodata in band_rasters:
@@ -440,6 +449,7 @@ async def _read_item_bands(
     chunk_height: int,
     nodata: float | None,
     store: object | None = None,
+    warp_cache: dict | None = None,
 ) -> dict[str, tuple[np.ndarray, float | None]] | None:
     """Read and reproject multiple bands from one STAC item, sharing warp maps.
 
@@ -459,6 +469,8 @@ async def _read_item_bands(
         nodata: No-data fill value.  When ``None``, the value stored in the
             COG header (``GeoTIFF.nodata``) is used if present.
         store: Optional pre-configured obstore ``ObjectStore`` instance.
+        warp_cache: Optional cache shared across calls for reusing warp maps
+            computed in earlier time steps.
 
     Returns:
         ``dict`` mapping band name to ``(array, effective_nodata)`` where
@@ -566,6 +578,7 @@ async def _read_item_bands(
             dst_crs,
             chunk_width,
             chunk_height,
+            warp_cache,
         ),
     )
     return results
@@ -582,6 +595,7 @@ async def async_mosaic_chunk_multiband(
     mosaic_method_cls: type[MosaicMethodBase] | None = None,
     store: object | None = None,
     max_concurrent_reads: int = 32,
+    warp_cache: dict | None = None,
 ) -> dict[str, np.ndarray]:
     """Read, reproject, and mosaic multiple bands from a list of STAC items.
 
@@ -605,6 +619,8 @@ async def async_mosaic_chunk_multiband(
             Defaults to :class:`~lazycogs._mosaic_methods.FirstMethod`.
         store: Optional pre-configured obstore ``ObjectStore`` instance.
         max_concurrent_reads: Maximum number of COG reads to run concurrently.
+        warp_cache: Optional cache shared across calls for reusing warp maps
+            from earlier time steps.
 
     Returns:
         ``dict`` mapping each band name to an array of shape
@@ -637,6 +653,7 @@ async def async_mosaic_chunk_multiband(
                 chunk_height,
                 nodata,
                 store=store,
+                warp_cache=warp_cache,
             )
 
     batch_size = min(max_concurrent_reads, len(items))

--- a/src/lazycogs/_reproject.py
+++ b/src/lazycogs/_reproject.py
@@ -2,9 +2,122 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 from affine import Affine
 from pyproj import CRS, Transformer
+
+
+@dataclass
+class WarpMap:
+    """Precomputed pixel-coordinate mapping from a destination grid to a source grid.
+
+    Stores the source column and row index for every destination pixel centre,
+    computed by a single vectorised ``Transformer.transform`` call.  The ``valid``
+    mask is not stored here; ``apply_warp_map`` derives it from the actual source
+    array shape so the same ``WarpMap`` can be reused across bands that share the
+    same source CRS and window transform but may have slightly different window
+    dimensions due to rounding.
+
+    Attributes:
+        src_col_idx: Source column indices, shape ``(dst_height, dst_width)``,
+            dtype ``intp``.  May contain out-of-bounds values for pixels that
+            map outside the source extent.
+        src_row_idx: Source row indices, shape ``(dst_height, dst_width)``,
+            dtype ``intp``.
+
+    """
+
+    src_col_idx: np.ndarray
+    src_row_idx: np.ndarray
+
+
+def compute_warp_map(
+    src_transform: Affine,
+    src_crs: CRS,
+    dst_transform: Affine,
+    dst_crs: CRS,
+    dst_width: int,
+    dst_height: int,
+) -> WarpMap:
+    """Build a pixel-coordinate mapping from destination grid to source grid.
+
+    Transforms every destination pixel centre into the source CRS with a single
+    vectorised ``Transformer.transform`` call, then converts to fractional source
+    pixel coordinates.  The result can be reused across multiple bands that share
+    the same source CRS and window transform via :func:`apply_warp_map`.
+
+    Args:
+        src_transform: Affine transform of the source array (window transform).
+        src_crs: CRS of the source array.
+        dst_transform: Affine transform of the destination grid.
+        dst_crs: CRS of the destination grid.
+        dst_width: Width of the destination grid in pixels.
+        dst_height: Height of the destination grid in pixels.
+
+    Returns:
+        :class:`WarpMap` with ``src_col_idx`` and ``src_row_idx`` arrays of
+        shape ``(dst_height, dst_width)``.
+
+    """
+    col_idx = np.arange(dst_width)
+    row_idx = np.arange(dst_height)
+    col_grid, row_grid = np.meshgrid(col_idx, row_idx)
+
+    dst_xs = dst_transform.c + (col_grid + 0.5) * dst_transform.a
+    dst_ys = dst_transform.f + (row_grid + 0.5) * dst_transform.e
+
+    transformer = Transformer.from_crs(dst_crs, src_crs, always_xy=True)
+    src_xs, src_ys = transformer.transform(dst_xs.ravel(), dst_ys.ravel())
+
+    # ~src_transform maps (x, y) → (col_frac, row_frac).
+    inv = ~src_transform
+    frac_cols = (inv.a * src_xs + inv.b * src_ys + inv.c).reshape(dst_height, dst_width)
+    frac_rows = (inv.d * src_xs + inv.e * src_ys + inv.f).reshape(dst_height, dst_width)
+
+    return WarpMap(
+        src_col_idx=np.floor(frac_cols).astype(np.intp),
+        src_row_idx=np.floor(frac_rows).astype(np.intp),
+    )
+
+
+def apply_warp_map(
+    data: np.ndarray,
+    warp_map: WarpMap,
+    nodata: float | None = None,
+) -> np.ndarray:
+    """Sample a source array using a precomputed :class:`WarpMap`.
+
+    The valid mask is derived from ``data.shape`` at call time so the same
+    ``warp_map`` can be safely applied to bands with slightly different window
+    dimensions.
+
+    Args:
+        data: Source data with shape ``(bands, src_h, src_w)``.
+        warp_map: Pixel-coordinate mapping from destination to source.
+        nodata: Fill value for destination pixels that fall outside the source
+            extent, or ``None`` to use zero.
+
+    Returns:
+        Array with shape ``(bands, dst_height, dst_width)`` and the same dtype
+        as ``data``.
+
+    """
+    bands, src_h, src_w = data.shape
+    dst_height, dst_width = warp_map.src_col_idx.shape
+    fill = nodata if nodata is not None else 0
+
+    valid = (
+        (warp_map.src_col_idx >= 0)
+        & (warp_map.src_col_idx < src_w)
+        & (warp_map.src_row_idx >= 0)
+        & (warp_map.src_row_idx < src_h)
+    )
+
+    out = np.full((bands, dst_height, dst_width), fill, dtype=data.dtype)
+    out[:, valid] = data[:, warp_map.src_row_idx[valid], warp_map.src_col_idx[valid]]
+    return out
 
 
 def reproject_array(
@@ -19,9 +132,10 @@ def reproject_array(
 ) -> np.ndarray:
     """Reproject a raster array using nearest-neighbor sampling.
 
-    Builds a dense warp map by transforming every destination pixel centre
-    into the source CRS with a single vectorised ``Transformer.transform``
-    call, then samples the source array with numpy fancy indexing.
+    Convenience wrapper around :func:`compute_warp_map` and
+    :func:`apply_warp_map`.  Use those functions directly when the same source
+    CRS and window transform are shared across multiple bands, so the warp map
+    can be computed once and reused.
 
     Args:
         data: Source data with shape ``(bands, src_h, src_w)``.
@@ -39,39 +153,7 @@ def reproject_array(
         the same dtype as ``data``.
 
     """
-    bands, src_h, src_w = data.shape
-    fill = nodata if nodata is not None else 0
-
-    # Grid of destination pixel-centre coordinates in dst_crs.
-    col_idx = np.arange(dst_width)
-    row_idx = np.arange(dst_height)
-    col_grid, row_grid = np.meshgrid(col_idx, row_idx)  # (dst_h, dst_w)
-
-    dst_xs = dst_transform.c + (col_grid + 0.5) * dst_transform.a
-    dst_ys = dst_transform.f + (row_grid + 0.5) * dst_transform.e
-
-    # Transform pixel centres from dst_crs to src_crs in one vectorised call.
-    transformer = Transformer.from_crs(dst_crs, src_crs, always_xy=True)
-    src_xs, src_ys = transformer.transform(dst_xs.ravel(), dst_ys.ravel())
-
-    # Convert src-CRS coordinates to fractional src pixel coordinates.
-    # ~src_transform maps (x, y) → (col_frac, row_frac) where the top-left
-    # corner of pixel (j, i) is at fractional coords (j, i).
-    inv = ~src_transform
-    frac_cols = (inv.a * src_xs + inv.b * src_ys + inv.c).reshape(dst_height, dst_width)
-    frac_rows = (inv.d * src_xs + inv.e * src_ys + inv.f).reshape(dst_height, dst_width)
-
-    src_col_idx = np.floor(frac_cols).astype(np.intp)
-    src_row_idx = np.floor(frac_rows).astype(np.intp)
-
-    valid = (
-        (src_col_idx >= 0)
-        & (src_col_idx < src_w)
-        & (src_row_idx >= 0)
-        & (src_row_idx < src_h)
+    warp_map = compute_warp_map(
+        src_transform, src_crs, dst_transform, dst_crs, dst_width, dst_height
     )
-
-    out = np.full((bands, dst_height, dst_width), fill, dtype=data.dtype)
-    out[:, valid] = data[:, src_row_idx[valid], src_col_idx[valid]]
-
-    return out
+    return apply_warp_map(data, warp_map, nodata)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,7 +7,7 @@ import pytest
 from affine import Affine
 from pyproj import CRS
 
-from lazycogs._backend import StacBackendArray
+from lazycogs._backend import MultiBandStacBackendArray, StacBackendArray
 from lazycogs._mosaic_methods import FirstMethod
 
 
@@ -168,3 +168,99 @@ def test_raw_getitem_chunk_affine_offset(wgs84):
     # If chunk_affine.c == 12, the bbox minx should be 12 in WGS84
     chunk_affine = arr.dst_affine * Affine.translation(2, 0)
     assert chunk_affine.c == pytest.approx(12.0)
+
+
+# ---------------------------------------------------------------------------
+# MultiBandStacBackendArray._raw_getitem
+# ---------------------------------------------------------------------------
+
+
+def _make_multiband_array(
+    crs: CRS, bands: list[str], dates: list[str] | None = None
+) -> MultiBandStacBackendArray:
+    """Return a minimal MultiBandStacBackendArray for unit testing."""
+    if dates is None:
+        dates = ["2023-01-01"]
+    band_arrays = [
+        StacBackendArray(
+            parquet_path="/tmp/fake.parquet",
+            band=b,
+            dates=dates,
+            dst_affine=Affine(1.0, 0.0, 10.0, 0.0, -1.0, 50.0),
+            dst_crs=crs,
+            bbox_4326=[10.0, 49.0, 14.0, 50.0],
+            sort_by=None,
+            filter=None,
+            ids=None,
+            dst_width=4,
+            dst_height=1,
+            dtype=np.dtype("float32"),
+            nodata=-9999.0,
+            shape=(len(dates), 1, 4),
+            mosaic_method_cls=FirstMethod,
+        )
+        for b in bands
+    ]
+    return MultiBandStacBackendArray(band_arrays=band_arrays, band_names=bands)
+
+
+def test_multiband_raw_getitem_no_items_returns_nodata(wgs84):
+    """When no items are found, all bands are filled with nodata."""
+    multi = _make_multiband_array(wgs84, ["B01", "B02"])
+
+    with patch("lazycogs._backend.rustac.search_sync", return_value=[]):
+        result = multi._raw_getitem(
+            (slice(0, 2), slice(0, 1), slice(0, 1), slice(0, 4))
+        )
+
+    assert result.shape == (2, 1, 1, 4)
+    np.testing.assert_array_equal(result, -9999.0)
+
+
+def test_multiband_raw_getitem_calls_multiband_mosaic(wgs84):
+    """_raw_getitem calls async_mosaic_chunk_multiband once per time step, not per band."""
+    bands = ["B01", "B02"]
+    multi = _make_multiband_array(wgs84, bands)
+    fake_items = [
+        {"id": "item-1", "assets": {b: {"href": f"s3://b/{b}.tif"} for b in bands}}
+    ]
+
+    call_count = [0]
+
+    def _fake_run_coroutine(coro):
+        call_count[0] += 1
+        coro.close()
+        return {
+            b: np.full((1, 1, 4), float(i), dtype=np.float32)
+            for i, b in enumerate(bands)
+        }
+
+    with (
+        patch("lazycogs._backend.rustac.search_sync", return_value=fake_items),
+        patch("lazycogs._backend._run_coroutine", side_effect=_fake_run_coroutine),
+    ):
+        result = multi._raw_getitem((slice(0, 2), 0, slice(0, 1), slice(0, 4)))
+
+    # One time step → one call to async_mosaic_chunk_multiband, not two.
+    assert call_count[0] == 1
+    assert result.shape == (2, 1, 4)
+
+
+def test_multiband_raw_getitem_squeeze_band(wgs84):
+    """Integer band index squeezes the band dimension."""
+    multi = _make_multiband_array(wgs84, ["B01", "B02"])
+
+    with patch("lazycogs._backend.rustac.search_sync", return_value=[]):
+        result = multi._raw_getitem((0, 0, slice(0, 1), slice(0, 4)))
+
+    assert result.shape == (1, 4)
+
+
+def test_multiband_raw_getitem_single_band_single_pixel(wgs84):
+    """All dimensions squeezed returns a scalar array."""
+    multi = _make_multiband_array(wgs84, ["B01", "B02"])
+
+    with patch("lazycogs._backend.rustac.search_sync", return_value=[]):
+        result = multi._raw_getitem((0, 0, 0, 0))
+
+    assert result.shape == ()

--- a/tests/test_chunk_reader.py
+++ b/tests/test_chunk_reader.py
@@ -1,4 +1,4 @@
-"""Tests for _chunk_reader helpers: _select_overview, _native_window, and async_mosaic_chunk."""
+"""Tests for _chunk_reader helpers: _select_overview, _native_window, and mosaic functions."""
 
 from __future__ import annotations
 
@@ -10,9 +10,11 @@ from affine import Affine
 from pyproj import CRS
 
 from lazycogs._chunk_reader import (
+    _apply_bands_with_warp_cache,
     _native_window,
     _select_overview,
     async_mosaic_chunk,
+    async_mosaic_chunk_multiband,
 )
 from lazycogs._mosaic_methods import FirstMethod
 
@@ -227,4 +229,163 @@ def test_async_mosaic_chunk_early_exit_skips_remaining_reads():
     # Only one batch of 5 should have been read; the mosaic fills on item 0
     # but the whole batch still runs.  Critically, the remaining 25 items
     # should NOT be read.
+    assert reads_executed[0] <= 5
+
+
+# ---------------------------------------------------------------------------
+# _apply_bands_with_warp_cache
+# ---------------------------------------------------------------------------
+
+
+def _make_raster(transform: Affine, value: float, h: int = 4, w: int = 4) -> MagicMock:
+    raster = MagicMock()
+    raster.transform = transform
+    raster.data = np.full((1, h, w), value, dtype=np.float32)
+    return raster
+
+
+def test_apply_bands_with_warp_cache_shared_geometry():
+    """Bands with the same transform/CRS share a single warp map computation."""
+    crs = CRS.from_epsg(4326)
+    transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+
+    raster_a = _make_raster(transform, 1.0)
+    raster_b = _make_raster(transform, 2.0)
+
+    warp_map_calls = []
+
+    def _spy_compute_warp_map(*args, **kwargs):
+        from lazycogs._reproject import compute_warp_map as _real
+
+        result = _real(*args, **kwargs)
+        warp_map_calls.append(True)
+        return result
+
+    with patch(
+        "lazycogs._chunk_reader.compute_warp_map", side_effect=_spy_compute_warp_map
+    ):
+        results = _apply_bands_with_warp_cache(
+            [("B01", raster_a, crs, None), ("B02", raster_b, crs, None)],
+            dst_transform,
+            crs,
+            dst_width=4,
+            dst_height=4,
+        )
+
+    # Same transform → warp map computed exactly once.
+    assert len(warp_map_calls) == 1
+    assert set(results) == {"B01", "B02"}
+    np.testing.assert_array_equal(results["B01"][0], 1.0)
+    np.testing.assert_array_equal(results["B02"][0], 2.0)
+
+
+def test_apply_bands_with_warp_cache_different_geometry():
+    """Bands with different transforms each compute their own warp map."""
+    crs = CRS.from_epsg(4326)
+    transform_a = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    transform_b = Affine(2.0, 0.0, 0.0, 0.0, -2.0, 8.0)
+    dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+
+    raster_a = _make_raster(transform_a, 1.0)
+    raster_b = _make_raster(transform_b, 2.0, h=2, w=2)
+
+    warp_map_calls = []
+
+    def _spy_compute_warp_map(*args, **kwargs):
+        from lazycogs._reproject import compute_warp_map as _real
+
+        result = _real(*args, **kwargs)
+        warp_map_calls.append(True)
+        return result
+
+    with patch(
+        "lazycogs._chunk_reader.compute_warp_map", side_effect=_spy_compute_warp_map
+    ):
+        results = _apply_bands_with_warp_cache(
+            [("B01", raster_a, crs, None), ("B02", raster_b, crs, None)],
+            dst_transform,
+            crs,
+            dst_width=4,
+            dst_height=4,
+        )
+
+    # Different transforms → two separate warp map computations.
+    assert len(warp_map_calls) == 2
+    assert set(results) == {"B01", "B02"}
+
+
+# ---------------------------------------------------------------------------
+# async_mosaic_chunk_multiband
+# ---------------------------------------------------------------------------
+
+
+def test_async_mosaic_chunk_multiband_returns_all_bands():
+    """Returns a dict with one entry per requested band."""
+    chunk_width, chunk_height = 4, 4
+    chunk_affine = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    dst_crs = CRS.from_epsg(4326)
+    bands = ["B01", "B02", "B03"]
+
+    async def _fake_read_item_bands(*args, **kwargs):
+        return {
+            b: (np.ones((1, chunk_height, chunk_width), dtype=np.float32), None)
+            for b in bands
+        }
+
+    items = [{"id": "item-0", "assets": {}}]
+
+    with patch(
+        "lazycogs._chunk_reader._read_item_bands", side_effect=_fake_read_item_bands
+    ):
+        result = asyncio.run(
+            async_mosaic_chunk_multiband(
+                items=items,
+                bands=bands,
+                chunk_affine=chunk_affine,
+                dst_crs=dst_crs,
+                chunk_width=chunk_width,
+                chunk_height=chunk_height,
+            )
+        )
+
+    assert set(result.keys()) == set(bands)
+    for b in bands:
+        assert result[b].shape == (1, chunk_height, chunk_width)
+
+
+def test_async_mosaic_chunk_multiband_early_exit():
+    """All bands filled on first item → remaining items are skipped."""
+    chunk_width, chunk_height = 4, 4
+    chunk_affine = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    dst_crs = CRS.from_epsg(4326)
+    bands = ["B01", "B02"]
+    reads_executed = [0]
+
+    async def _fake_read_item_bands(*args, **kwargs):
+        reads_executed[0] += 1
+        return {
+            b: (np.ones((1, chunk_height, chunk_width), dtype=np.float32), None)
+            for b in bands
+        }
+
+    items = [{"id": f"item-{i}", "assets": {}} for i in range(20)]
+
+    with patch(
+        "lazycogs._chunk_reader._read_item_bands", side_effect=_fake_read_item_bands
+    ):
+        asyncio.run(
+            async_mosaic_chunk_multiband(
+                items=items,
+                bands=bands,
+                chunk_affine=chunk_affine,
+                dst_crs=dst_crs,
+                chunk_width=chunk_width,
+                chunk_height=chunk_height,
+                mosaic_method_cls=FirstMethod,
+                max_concurrent_reads=5,
+            )
+        )
+
+    # FirstMethod fills on first item; only the first batch of 5 should run.
     assert reads_executed[0] <= 5

--- a/tests/test_chunk_reader.py
+++ b/tests/test_chunk_reader.py
@@ -315,6 +315,49 @@ def test_apply_bands_with_warp_cache_different_geometry():
     assert set(results) == {"B01", "B02"}
 
 
+def test_apply_bands_with_warp_cache_shared_across_calls():
+    """A shared external cache reuses warp maps across separate calls (e.g. time steps)."""
+    crs = CRS.from_epsg(4326)
+    transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+
+    raster = _make_raster(transform, 1.0)
+    shared_cache: dict = {}
+
+    warp_map_calls = []
+
+    def _spy_compute_warp_map(*args, **kwargs):
+        from lazycogs._reproject import compute_warp_map as _real
+
+        result = _real(*args, **kwargs)
+        warp_map_calls.append(True)
+        return result
+
+    with patch(
+        "lazycogs._chunk_reader.compute_warp_map", side_effect=_spy_compute_warp_map
+    ):
+        _apply_bands_with_warp_cache(
+            [("B01", raster, crs, None)],
+            dst_transform,
+            crs,
+            dst_width=4,
+            dst_height=4,
+            warp_cache=shared_cache,
+        )
+        _apply_bands_with_warp_cache(
+            [("B01", raster, crs, None)],
+            dst_transform,
+            crs,
+            dst_width=4,
+            dst_height=4,
+            warp_cache=shared_cache,
+        )
+
+    # Warp map computed only once despite two separate calls.
+    assert len(warp_map_calls) == 1
+    assert len(shared_cache) == 1
+
+
 # ---------------------------------------------------------------------------
 # async_mosaic_chunk_multiband
 # ---------------------------------------------------------------------------

--- a/tests/test_reproject.py
+++ b/tests/test_reproject.py
@@ -1,11 +1,16 @@
-"""Tests for _reproject.reproject_array."""
+"""Tests for _reproject: reproject_array, compute_warp_map, apply_warp_map."""
 
 import numpy as np
 import pytest
 from affine import Affine
 from pyproj import CRS
 
-from lazycogs._reproject import reproject_array
+from lazycogs._reproject import (
+    WarpMap,
+    apply_warp_map,
+    compute_warp_map,
+    reproject_array,
+)
 
 
 @pytest.fixture
@@ -118,3 +123,68 @@ def test_partial_overlap_nodata(wgs84):
     # x=2 and x=3 overlap source (values 7); x=4 and x=5 are outside
     np.testing.assert_array_equal(out[0, 0, :2], 7.0)
     np.testing.assert_array_equal(out[0, 0, 2:], -1.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_warp_map / apply_warp_map
+# ---------------------------------------------------------------------------
+
+
+def test_compute_warp_map_returns_correct_shape(wgs84):
+    """WarpMap arrays have shape (dst_height, dst_width)."""
+    transform = _make_transform(0.0, 4.0, 1.0)
+    wm = compute_warp_map(transform, wgs84, transform, wgs84, dst_width=4, dst_height=3)
+    assert isinstance(wm, WarpMap)
+    assert wm.src_col_idx.shape == (3, 4)
+    assert wm.src_row_idx.shape == (3, 4)
+
+
+def test_apply_warp_map_matches_reproject_array(wgs84):
+    """apply_warp_map with a precomputed map gives the same result as reproject_array."""
+    src_transform = _make_transform(0.0, 3.0, 1.0)
+    dst_transform = _make_transform(0.0, 3.0, 1.0)
+    data = np.arange(9, dtype=np.float32).reshape(1, 3, 3)
+
+    wm = compute_warp_map(src_transform, wgs84, dst_transform, wgs84, 3, 3)
+    out_warp = apply_warp_map(data, wm, nodata=0.0)
+    out_reproject = reproject_array(
+        data, src_transform, wgs84, dst_transform, wgs84, 3, 3, nodata=0.0
+    )
+    np.testing.assert_array_equal(out_warp, out_reproject)
+
+
+def test_apply_warp_map_reused_across_bands(wgs84):
+    """A single WarpMap applied to two bands gives the same result as reproject_array per band."""
+    transform = _make_transform(0.0, 2.0, 1.0)
+    band_a = np.full((1, 2, 2), 1.0, dtype=np.float32)
+    band_b = np.full((1, 2, 2), 2.0, dtype=np.float32)
+
+    wm = compute_warp_map(transform, wgs84, transform, wgs84, 2, 2)
+
+    out_a = apply_warp_map(band_a, wm)
+    out_b = apply_warp_map(band_b, wm)
+
+    np.testing.assert_array_equal(
+        out_a, reproject_array(band_a, transform, wgs84, transform, wgs84, 2, 2)
+    )
+    np.testing.assert_array_equal(
+        out_b, reproject_array(band_b, transform, wgs84, transform, wgs84, 2, 2)
+    )
+
+
+def test_apply_warp_map_different_src_dimensions(wgs84):
+    """apply_warp_map derives valid mask from actual data shape, not stored metadata."""
+    # Compute warp map for a 4×4 source extent.
+    src_transform = _make_transform(0.0, 4.0, 1.0)
+    dst_transform = _make_transform(0.0, 4.0, 1.0)
+    wm = compute_warp_map(src_transform, wgs84, dst_transform, wgs84, 4, 4)
+
+    # Apply to a 3×3 source array — pixels that map to row/col >= 3 should use nodata.
+    data_small = np.ones((1, 3, 3), dtype=np.float32)
+    out = apply_warp_map(data_small, wm, nodata=-1.0)
+
+    # Top-left 3×3 destination pixels map into the valid 3×3 source.
+    np.testing.assert_array_equal(out[0, :3, :3], 1.0)
+    # Bottom row and right column of destination map outside the 3×3 source.
+    np.testing.assert_array_equal(out[0, 3, :], -1.0)
+    np.testing.assert_array_equal(out[0, :, 3], -1.0)


### PR DESCRIPTION
The most resource intensive process in the whole process is the array transformations. We can save some compute by cacheing the transforms and reusing them across bands and time steps instead of performing the same exact computation multiple times.