### PR TITLE
feat: skip reprojection when read window already matches destination grid

### DIFF
--- a/src/lazycogs/__init__.py
+++ b/src/lazycogs/__init__.py
@@ -2,6 +2,7 @@
 
 from lazycogs._core import open, open_async
 from lazycogs._executor import set_reproject_workers
+from lazycogs._native_grid import NativeGrid, native_grid
 from lazycogs._store import store_for
 from lazycogs._explain import (  # noqa: F401 — registers da.stac_cog accessor
     ChunkRead,
@@ -23,6 +24,8 @@ from lazycogs._mosaic_methods import (
 __all__ = [
     "open",
     "open_async",
+    "native_grid",
+    "NativeGrid",
     "store_for",
     "set_reproject_workers",
     "ExplainPlan",

--- a/src/lazycogs/_chunk_reader.py
+++ b/src/lazycogs/_chunk_reader.py
@@ -282,6 +282,17 @@ async def _read_item_band(
         time.perf_counter() - t0,
     )
 
+    # Fast path: skip reprojection when the read window already matches the
+    # destination chunk exactly (same CRS, same affine, same pixel dimensions).
+    if (
+        geotiff.crs.equals(dst_crs)
+        and raster.transform == chunk_affine
+        and raster.data.shape[1] == chunk_height
+        and raster.data.shape[2] == chunk_width
+    ):
+        logger.debug("Skipping reprojection for %s (identity grid)", path)
+        return raster.data, effective_nodata
+
     # Reproject to the destination chunk grid.
     # Run in a thread executor so the event loop stays free to process
     # concurrent I/O completions from other items in the same gather.
@@ -469,6 +480,16 @@ def _apply_bands_with_warp_cache(
     results: dict[str, tuple[np.ndarray, float | None]] = {}
 
     for band, raster, src_crs, effective_nodata in band_rasters:
+        # Fast path: skip reprojection when the read window already matches the
+        # destination chunk exactly (same CRS, same affine, same pixel dimensions).
+        if (
+            src_crs.equals(dst_crs)
+            and raster.transform == dst_transform
+            and raster.data.shape[1] == dst_height
+            and raster.data.shape[2] == dst_width
+        ):
+            results[band] = (raster.data, effective_nodata)
+            continue
         cache_key = (tuple(raster.transform), src_crs)
         if cache_key not in cache:
             cache[cache_key] = compute_warp_map(

--- a/src/lazycogs/_native_grid.py
+++ b/src/lazycogs/_native_grid.py
@@ -1,0 +1,249 @@
+"""Discover the native CRS and pixel grid of a STAC COG collection."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from affine import Affine
+from pyproj import CRS, Transformer
+from rustac import DuckdbClient
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass(frozen=True)
+class NativeGrid:
+    """Native CRS, resolution, and pixel-snapped bbox for a STAC collection.
+
+    Produced by :func:`lazycogs.native_grid` and consumed directly by
+    :func:`lazycogs.open`::
+
+        grid = lazycogs.native_grid("items.parquet", bbox=[-108.5, 37.5, -107.5, 38.5])
+        da = lazycogs.open(
+            "items.parquet",
+            bbox=grid.bbox,
+            crs=grid.crs,
+            resolution=grid.resolution,
+        )
+
+    Attributes:
+        crs: Authority string for the native CRS (e.g. ``"EPSG:32612"``).
+        resolution: Native pixel size in CRS units.
+        bbox: ``(minx, miny, maxx, maxy)`` in the native CRS, snapped outward
+            to the nearest pixel-grid boundary so that :func:`lazycogs.open`
+            can use the no-reprojection fast path.
+    """
+
+    crs: str
+    resolution: float
+    bbox: tuple[float, float, float, float]
+
+
+def _epsg_from_item(item: dict[str, Any]) -> int | None:
+    """Return the EPSG code from an item's properties, or ``None``."""
+    return item.get("properties", {}).get("proj:epsg")
+
+
+def _transform_from_asset(asset: dict[str, Any], band: str, item_id: str) -> Affine:
+    """Extract the ``Affine`` transform from an asset's ``proj:transform`` field.
+
+    Raises:
+        ValueError: If ``proj:transform`` is absent from the asset.
+    """
+    pt = asset.get("proj:transform")
+    if pt is None:
+        raise ValueError(
+            f"Asset {band!r} in item {item_id!r} is missing 'proj:transform'. "
+            "Ensure the collection uses the STAC projection extension "
+            "(https://github.com/stac-extensions/projection)."
+        )
+    a, b, c, d, e, f = pt[:6]
+    return Affine(a, b, c, d, e, f)
+
+
+def _snap_bbox(
+    proj_minx: float,
+    proj_miny: float,
+    proj_maxx: float,
+    proj_maxy: float,
+    grid_transform: Affine,
+) -> tuple[float, float, float, float]:
+    """Snap a projected bbox outward to the nearest pixel-grid boundary.
+
+    Args:
+        proj_minx: Minimum x coordinate in the native CRS.
+        proj_miny: Minimum y coordinate in the native CRS.
+        proj_maxx: Maximum x coordinate in the native CRS.
+        proj_maxy: Maximum y coordinate in the native CRS.
+        grid_transform: Affine transform whose origin and pixel size define the
+            native pixel grid.
+
+    Returns:
+        ``(minx, miny, maxx, maxy)`` snapped to pixel boundaries, guaranteed
+        to contain the input bbox.
+    """
+    ox = grid_transform.c
+    px = grid_transform.a  # positive pixel width
+    oy = grid_transform.f
+    py = grid_transform.e  # negative pixel height
+
+    snapped_minx = ox + math.floor((proj_minx - ox) / px) * px
+    snapped_maxx = ox + math.ceil((proj_maxx - ox) / px) * px
+    # py is negative, so floor/ceil roles are swapped for y.
+    snapped_maxy = oy + math.floor((proj_maxy - oy) / py) * py
+    snapped_miny = oy + math.ceil((proj_miny - oy) / py) * py
+
+    return snapped_minx, snapped_miny, snapped_maxx, snapped_maxy
+
+
+def native_grid(
+    parquet: str,
+    bbox: tuple[float, float, float, float],
+    bands: list[str] | None = None,
+    *,
+    datetime: str | None = None,
+    duckdb_client: DuckdbClient | None = None,
+) -> NativeGrid:
+    """Discover the native CRS and resolution for a STAC COG collection.
+
+    Reads ``proj:epsg`` and ``proj:transform`` from STAC item asset metadata
+    (populated by the `STAC projection extension
+    <https://github.com/stac-extensions/projection>`_) without opening any COG
+    files.  Returns the shared native CRS and pixel size, plus a
+    pixel-grid-aligned version of *bbox* that enables the no-reprojection fast
+    path in :func:`lazycogs.open`.
+
+    Example::
+
+        grid = lazycogs.native_grid(
+            "sentinel2.parquet",
+            bbox=[-108.5, 37.5, -107.5, 38.5],
+            bands=["red"],
+        )
+        da = lazycogs.open(
+            "sentinel2.parquet",
+            bbox=grid.bbox,
+            crs=grid.crs,
+            resolution=grid.resolution,
+        )
+
+    Args:
+        parquet: Path to a geoparquet file (``.parquet`` or ``.geoparquet``)
+            or a hive-partitioned parquet directory when *duckdb_client* is
+            provided.
+        bbox: ``(minx, miny, maxx, maxy)`` in EPSG:4326 describing the area of
+            interest.  The returned :attr:`NativeGrid.bbox` covers at least
+            this area.
+        bands: Asset keys to inspect.  When ``None``, all data assets from the
+            first matching item are used.  All requested bands must share the
+            same native resolution; pass a single band name when bands have
+            different native resolutions (e.g. Sentinel-2 10 m red vs 20 m
+            NIR).
+        datetime: RFC 3339 datetime or interval (e.g. ``"2024-06-01/2024-06-30"``)
+            to filter items before inspecting their metadata.
+        duckdb_client: Optional ``DuckdbClient`` instance for hive-partitioned
+            datasets.  Defaults to a plain ``DuckdbClient()``.
+
+    Returns:
+        :class:`NativeGrid` containing the shared ``crs``, native
+        ``resolution``, and a pixel-grid-aligned ``bbox`` in the native CRS.
+
+    Raises:
+        ValueError: If no matching items are found; if ``bands`` are absent
+            from the asset metadata; if ``proj:transform`` is missing from any
+            asset; if items do not share a common CRS (e.g. a bbox spanning two
+            UTM zones); or if the requested bands have different native
+            resolutions.
+    """
+    if duckdb_client is None:
+        duckdb_client = DuckdbClient()
+
+    items = duckdb_client.search(parquet, bbox=list(bbox), datetime=datetime)
+    if not items:
+        raise ValueError(f"No STAC items found in {parquet!r} for bbox={bbox}")
+
+    # Determine which bands to inspect from the first item when not specified.
+    first_assets: dict[str, Any] = items[0].get("assets", {})
+    if bands is None:
+        bands = [
+            k
+            for k, v in first_assets.items()
+            if "data" in v.get("roles", []) or "image/tiff" in v.get("type", "")
+        ] or list(first_assets)
+
+    crs_values: set[int] = set()
+    # One representative transform per band (pixel size and grid origin).
+    band_transforms: dict[str, Affine] = {}
+
+    for item in items:
+        epsg = _epsg_from_item(item)
+        if epsg is not None:
+            crs_values.add(epsg)
+
+        item_id: str = item.get("id", "<unknown>")
+        assets = item.get("assets", {})
+        for band in bands:
+            asset = assets.get(band)
+            if asset is None:
+                continue
+            transform = _transform_from_asset(asset, band, item_id)
+            if band in band_transforms:
+                existing = band_transforms[band]
+                if abs(existing.a) != abs(transform.a) or abs(existing.e) != abs(
+                    transform.e
+                ):
+                    raise ValueError(
+                        f"Band {band!r} has inconsistent native pixel size across "
+                        f"items ({abs(existing.a)} vs {abs(transform.a)} CRS units). "
+                        "Narrow the bbox to a single tile."
+                    )
+            else:
+                band_transforms[band] = transform
+
+    missing = [b for b in bands if b not in band_transforms]
+    if missing:
+        raise ValueError(f"Band(s) {missing} not found in any matching item's assets.")
+
+    if not crs_values:
+        raise ValueError(
+            "No 'proj:epsg' found in item properties. Ensure the collection "
+            "uses the STAC projection extension."
+        )
+    if len(crs_values) > 1:
+        raise ValueError(
+            f"Items span multiple CRSs: {crs_values}. "
+            "Narrow the bbox to a single UTM zone or tile."
+        )
+
+    resolutions = {band: abs(t.a) for band, t in band_transforms.items()}
+    unique_res = set(resolutions.values())
+    if len(unique_res) > 1:
+        raise ValueError(
+            f"Requested bands have different native resolutions: {resolutions}. "
+            "Specify a single band name to get a unique native resolution."
+        )
+
+    epsg = next(iter(crs_values))
+    resolution = unique_res.pop()
+    grid_transform = next(iter(band_transforms.values()))
+
+    src_crs = CRS.from_epsg(4326)
+    dst_crs = CRS.from_epsg(epsg)
+    transformer = Transformer.from_crs(src_crs, dst_crs, always_xy=True)
+
+    minx_4326, miny_4326, maxx_4326, maxy_4326 = bbox
+    xs, ys = transformer.transform(
+        [minx_4326, maxx_4326, minx_4326, maxx_4326],
+        [miny_4326, miny_4326, maxy_4326, maxy_4326],
+    )
+    proj_minx, proj_maxx = min(xs), max(xs)
+    proj_miny, proj_maxy = min(ys), max(ys)
+
+    snapped_bbox = _snap_bbox(
+        proj_minx, proj_miny, proj_maxx, proj_maxy, grid_transform
+    )
+
+    return NativeGrid(crs=f"EPSG:{epsg}", resolution=resolution, bbox=snapped_bbox)

--- a/tests/benchmarks/bench_pipeline.py
+++ b/tests/benchmarks/bench_pipeline.py
@@ -16,6 +16,9 @@ from .conftest import (
     BENCHMARK_BBOX,
     BENCHMARK_CRS,
     BENCHMARK_MULTIBAND,
+    BENCHMARK_NATIVE_BBOX,
+    BENCHMARK_NATIVE_CRS,
+    BENCHMARK_NATIVE_RESOLUTION,
     BENCHMARK_SINGLE_BAND,
 )
 
@@ -103,6 +106,28 @@ def test_reproject_workers(
     finally:
         # Reset to default so other benchmarks are not affected.
         set_reproject_workers(min(__import__("os").cpu_count() or 4, 4))
+
+
+@pytest.mark.benchmark
+def test_native_crs_resolution(benchmark, benchmark_parquet: str) -> None:
+    """Full pipeline using the assets' native CRS and resolution.
+
+    Requests data in EPSG:32612 at 10 m — exactly the source COG projection and
+    pixel size — so reprojection should be a no-op.  Compared against
+    ``test_full_compute`` (which reprojects to EPSG:5070 at 60 m) to quantify
+    the overhead of the warp path when it is not needed.
+    """
+
+    def run() -> object:
+        da = lazycogs.open(
+            benchmark_parquet,
+            bbox=BENCHMARK_NATIVE_BBOX,
+            crs=BENCHMARK_NATIVE_CRS,
+            resolution=BENCHMARK_NATIVE_RESOLUTION,
+        )
+        return da.compute()
+
+    benchmark(run)
 
 
 @pytest.mark.benchmark

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -22,6 +22,16 @@ BENCHMARK_CRS = "EPSG:5070"
 BENCHMARK_SINGLE_BAND: list[str] = ["red"]
 BENCHMARK_MULTIBAND: list[str] = ["red", "nir08"]
 
+# Native CRS/resolution for the benchmark dataset (Sentinel-2 UTM Zone 12N).
+# Used to benchmark the no-reprojection path.
+BENCHMARK_NATIVE_CRS = "EPSG:32612"
+# 30 km x 30 km area fully within the source COG footprint, snapped to the
+# native 10 m pixel grid so col_off and row_off are whole numbers.
+# Source transform origin: (699960, 4200000), pixel size: (10, -10).
+# col_off=1000, row_off=200 from the top-left corner.
+BENCHMARK_NATIVE_BBOX = (709960.0, 4_168_000.0, 739960.0, 4_198_000.0)
+BENCHMARK_NATIVE_RESOLUTION = 10.0  # red band native pixel size
+
 
 @pytest.fixture(scope="session")
 def benchmark_parquet() -> str:

--- a/tests/test_chunk_reader.py
+++ b/tests/test_chunk_reader.py
@@ -254,7 +254,9 @@ def _make_raster(transform: Affine, value: float, h: int = 4, w: int = 4) -> Mag
 def test_apply_bands_with_warp_cache_shared_geometry():
     """Bands with the same transform/CRS share a single warp map computation."""
     crs = CRS.from_epsg(4326)
-    transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    # Offset the source transform slightly so it differs from dst_transform and
+    # the warp path (rather than the identity fast-path) is exercised.
+    transform = Affine(1.0, 0.0, 0.5, 0.0, -1.0, 4.0)
     dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
 
     raster_a = _make_raster(transform, 1.0)
@@ -290,7 +292,9 @@ def test_apply_bands_with_warp_cache_shared_geometry():
 def test_apply_bands_with_warp_cache_different_geometry():
     """Bands with different transforms each compute their own warp map."""
     crs = CRS.from_epsg(4326)
-    transform_a = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    # Both source transforms differ from dst_transform so the warp path is
+    # exercised for each band (fast-path is not triggered).
+    transform_a = Affine(1.0, 0.0, 0.5, 0.0, -1.0, 4.0)
     transform_b = Affine(2.0, 0.0, 0.0, 0.0, -2.0, 8.0)
     dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
 
@@ -325,7 +329,8 @@ def test_apply_bands_with_warp_cache_different_geometry():
 def test_apply_bands_with_warp_cache_shared_across_calls():
     """A shared external cache reuses warp maps across separate calls (e.g. time steps)."""
     crs = CRS.from_epsg(4326)
-    transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+    # Source transform offset from dst so the warp path is exercised.
+    transform = Affine(1.0, 0.0, 0.5, 0.0, -1.0, 4.0)
     dst_transform = Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
 
     raster = _make_raster(transform, 1.0)

--- a/tests/test_native_grid.py
+++ b/tests/test_native_grid.py
@@ -1,0 +1,256 @@
+"""Tests for lazycogs._native_grid."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+from affine import Affine
+
+from lazycogs._native_grid import NativeGrid, _snap_bbox, native_grid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    item_id: str = "item-0",
+    epsg: int = 32612,
+    red_transform: list[float] | None = None,
+    nir_transform: list[float] | None = None,
+) -> dict:
+    """Build a minimal STAC item dict with projection extension fields."""
+    if red_transform is None:
+        red_transform = [10, 0, 699960, 0, -10, 4200000]
+    assets: dict = {
+        "red": {
+            "href": f"file:///cogs/{item_id}/red.tif",
+            "type": "image/tiff; application=geotiff",
+            "roles": ["data"],
+            "proj:shape": [10980, 10980],
+            "proj:transform": red_transform,
+        }
+    }
+    if nir_transform is not None:
+        assets["nir08"] = {
+            "href": f"file:///cogs/{item_id}/nir08.tif",
+            "type": "image/tiff; application=geotiff",
+            "roles": ["data"],
+            "proj:shape": [5490, 5490],
+            "proj:transform": nir_transform,
+        }
+    return {
+        "id": item_id,
+        "properties": {"datetime": "2025-07-04T00:00:00Z", "proj:epsg": epsg},
+        "assets": assets,
+    }
+
+
+def _mock_duckdb_client(items: list[dict]) -> MagicMock:
+    """Return a DuckdbClient mock whose search() always returns *items*."""
+    client = MagicMock()
+    client.search.return_value = items
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _snap_bbox
+# ---------------------------------------------------------------------------
+
+
+def test_snap_bbox_aligned_input():
+    """A bbox already on the pixel grid is returned unchanged."""
+    transform = Affine(10.0, 0.0, 699960.0, 0.0, -10.0, 4200000.0)
+    bbox = _snap_bbox(709960.0, 4168000.0, 739960.0, 4198000.0, transform)
+    assert bbox == pytest.approx((709960.0, 4168000.0, 739960.0, 4198000.0))
+
+
+def test_snap_bbox_expands_outward():
+    """A non-aligned bbox is snapped outward to fully contain the input."""
+    transform = Affine(10.0, 0.0, 699960.0, 0.0, -10.0, 4200000.0)
+    # Slightly inside grid boundaries on all sides.
+    bbox = _snap_bbox(709965.0, 4168005.0, 739955.0, 4197995.0, transform)
+    snapped_minx, snapped_miny, snapped_maxx, snapped_maxy = bbox
+    assert snapped_minx <= 709965.0
+    assert snapped_miny <= 4168005.0
+    assert snapped_maxx >= 739955.0
+    assert snapped_maxy >= 4197995.0
+
+
+def test_snap_bbox_boundaries_on_grid():
+    """Snapped corners always land exactly on pixel boundaries."""
+    transform = Affine(10.0, 0.0, 699960.0, 0.0, -10.0, 4200000.0)
+    bbox = _snap_bbox(709963.0, 4168007.0, 739957.0, 4197992.0, transform)
+    ox, px = transform.c, transform.a
+    oy, py = transform.f, transform.e
+    minx, miny, maxx, maxy = bbox
+    assert math.isclose((minx - ox) % px, 0.0, abs_tol=1e-6)
+    assert math.isclose((maxx - ox) % px, 0.0, abs_tol=1e-6)
+    assert math.isclose((maxy - oy) % py, 0.0, abs_tol=1e-6)
+    assert math.isclose((miny - oy) % py, 0.0, abs_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# native_grid
+# ---------------------------------------------------------------------------
+
+
+def test_native_grid_returns_correct_crs_and_resolution():
+    """CRS and resolution are extracted from proj:epsg and proj:transform."""
+    item = _make_item(epsg=32612, red_transform=[10, 0, 699960, 0, -10, 4200000])
+    client = _mock_duckdb_client([item])
+    result = native_grid(
+        "fake.parquet",
+        bbox=(-108.5, 37.5, -107.5, 38.5),
+        bands=["red"],
+        duckdb_client=client,
+    )
+    assert result.crs == "EPSG:32612"
+    assert result.resolution == 10.0
+
+
+def test_native_grid_bbox_is_in_native_crs():
+    """The returned bbox is in the native CRS (larger coords than WGS-84 degrees)."""
+    item = _make_item(epsg=32612)
+    client = _mock_duckdb_client([item])
+    result = native_grid(
+        "fake.parquet",
+        bbox=(-108.5, 37.5, -107.5, 38.5),
+        bands=["red"],
+        duckdb_client=client,
+    )
+    minx, miny, maxx, maxy = result.bbox
+    # UTM coordinates are in metres, so values should be much larger than degrees.
+    assert minx > 10_000
+    assert miny > 10_000
+
+
+def test_native_grid_bbox_snapped_to_grid():
+    """The returned bbox corners fall on the native pixel grid."""
+    transform_list = [10, 0, 699960, 0, -10, 4200000]
+    item = _make_item(red_transform=transform_list)
+    client = _mock_duckdb_client([item])
+    result = native_grid(
+        "fake.parquet",
+        bbox=(-108.5, 37.5, -107.5, 38.5),
+        bands=["red"],
+        duckdb_client=client,
+    )
+    ox, px = 699960.0, 10.0
+    oy, py = 4200000.0, -10.0
+    minx, miny, maxx, maxy = result.bbox
+    assert math.isclose((minx - ox) % px, 0.0, abs_tol=1e-3)
+    assert math.isclose((maxx - ox) % px, 0.0, abs_tol=1e-3)
+    assert math.isclose((maxy - oy) % py, 0.0, abs_tol=1e-3)
+    assert math.isclose((miny - oy) % py, 0.0, abs_tol=1e-3)
+
+
+def test_native_grid_bbox_contains_projected_input():
+    """The snapped bbox contains the projected version of the input bbox."""
+    from pyproj import Transformer
+
+    item = _make_item(epsg=32612)
+    client = _mock_duckdb_client([item])
+    input_bbox = (-108.5, 37.5, -107.5, 38.5)
+    result = native_grid(
+        "fake.parquet", bbox=input_bbox, bands=["red"], duckdb_client=client
+    )
+    t = Transformer.from_crs(4326, 32612, always_xy=True)
+    xs, ys = t.transform(
+        [input_bbox[0], input_bbox[2], input_bbox[0], input_bbox[2]],
+        [input_bbox[1], input_bbox[1], input_bbox[3], input_bbox[3]],
+    )
+    assert result.bbox[0] <= min(xs)
+    assert result.bbox[1] <= min(ys)
+    assert result.bbox[2] >= max(xs)
+    assert result.bbox[3] >= max(ys)
+
+
+def test_native_grid_no_items_raises():
+    """A ValueError is raised when the parquet query returns no items."""
+    client = _mock_duckdb_client([])
+    with pytest.raises(ValueError, match="No STAC items found"):
+        native_grid("fake.parquet", bbox=(-1.0, -1.0, 1.0, 1.0), duckdb_client=client)
+
+
+def test_native_grid_mixed_crs_raises():
+    """Items spanning multiple CRSs raise a ValueError."""
+    item_a = _make_item("a", epsg=32612)
+    item_b = _make_item("b", epsg=32613)
+    client = _mock_duckdb_client([item_a, item_b])
+    with pytest.raises(ValueError, match="multiple CRSs"):
+        native_grid(
+            "fake.parquet", bbox=(-110.0, 37.0, -105.0, 39.0), duckdb_client=client
+        )
+
+
+def test_native_grid_missing_proj_transform_raises():
+    """An asset without proj:transform raises a descriptive ValueError."""
+    item = _make_item()
+    del item["assets"]["red"]["proj:transform"]
+    client = _mock_duckdb_client([item])
+    with pytest.raises(ValueError, match="proj:transform"):
+        native_grid(
+            "fake.parquet", bbox=(-108.5, 37.5, -107.5, 38.5), duckdb_client=client
+        )
+
+
+def test_native_grid_missing_band_raises():
+    """Requesting a band absent from all items raises a ValueError."""
+    item = _make_item()
+    client = _mock_duckdb_client([item])
+    with pytest.raises(ValueError, match="not found"):
+        native_grid(
+            "fake.parquet",
+            bbox=(-108.5, 37.5, -107.5, 38.5),
+            bands=["scl"],
+            duckdb_client=client,
+        )
+
+
+def test_native_grid_mixed_resolution_raises():
+    """Bands with different native resolutions raise a ValueError."""
+    item = _make_item(
+        red_transform=[10, 0, 699960, 0, -10, 4200000],
+        nir_transform=[20, 0, 699960, 0, -20, 4200000],
+    )
+    client = _mock_duckdb_client([item])
+    with pytest.raises(ValueError, match="different native resolutions"):
+        native_grid(
+            "fake.parquet",
+            bbox=(-108.5, 37.5, -107.5, 38.5),
+            bands=["red", "nir08"],
+            duckdb_client=client,
+        )
+
+
+def test_native_grid_infers_bands_from_first_item():
+    """When bands=None, data assets from the first item are used."""
+    item = _make_item(
+        red_transform=[10, 0, 699960, 0, -10, 4200000],
+    )
+    client = _mock_duckdb_client([item])
+    result = native_grid(
+        "fake.parquet", bbox=(-108.5, 37.5, -107.5, 38.5), duckdb_client=client
+    )
+    assert result.resolution == 10.0
+
+
+def test_native_grid_nine_element_transform():
+    """A 9-element proj:transform (with the identity last row) is handled."""
+    item = _make_item(red_transform=[10, 0, 699960, 0, -10, 4200000, 0, 0, 1])
+    client = _mock_duckdb_client([item])
+    result = native_grid(
+        "fake.parquet", bbox=(-108.5, 37.5, -107.5, 38.5), duckdb_client=client
+    )
+    assert result.resolution == 10.0
+
+
+def test_native_grid_result_is_frozen():
+    """NativeGrid instances are immutable."""
+    grid = NativeGrid(crs="EPSG:32612", resolution=10.0, bbox=(0.0, 0.0, 1.0, 1.0))
+    with pytest.raises((AttributeError, TypeError)):
+        grid.crs = "EPSG:4326"  # type: ignore[misc]


### PR DESCRIPTION
When a user opens data in the assets' native CRS at the native resolution and the output bbox is pixel-grid-aligned, the windowed read produces a chunk that is already on the destination grid. The previous code still ran the full warp pipeline (compute_warp_map + apply_warp_map) in that case.

This PR adds:

- A fast-path check in `_read_item_band` and `_apply_bands_with_warp_cache` that returns the raw read data directly when src_crs == dst_crs, src_transform == dst_transform, and the array shape matches. Benchmark shows ~11% speedup (6.94 s → 6.21 s mean) for the native-grid case.

- `lazycogs.native_grid(parquet, bbox, bands, ...)` helper that reads proj:epsg and proj:transform from STAC asset metadata (no COG I/O) and returns a NativeGrid(crs, resolution, bbox) with the bbox reprojected to the native CRS and snapped outward to the pixel grid, making it straightforward to hit the fast path.

- A `test_native_crs_resolution` benchmark and updated conftest constants for the native-grid scenario.