### PR TITLE
chore: correctly describe dimension order in docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture: lazycogs
 
-lazycogs turns a geoparquet STAC item index into a lazy `(time, band, y, x)` xarray DataArray backed by Cloud-Optimized GeoTIFFs. It requires no GDAL. All raster I/O is done through `async-geotiff` (Rust-backed), spatial queries go through DuckDB via `rustac`, and reprojection is pure `pyproj` + numpy.
+lazycogs turns a geoparquet STAC item index into a lazy `(band, time, y, x)` xarray DataArray backed by Cloud-Optimized GeoTIFFs. It requires no GDAL. All raster I/O is done through `async-geotiff` (Rust-backed), spatial queries go through DuckDB via `rustac`, and reprojection is pure `pyproj` + numpy.
 
 ## Why parquet, not a STAC API URL
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/lazycogs)](https://pypi.org/project/lazycogs/)
 [![License](https://img.shields.io/github/license/developmentseed/lazycogs)](https://github.com/developmentseed/lazycogs/blob/main/LICENSE)
 
-Open a lazy `(time, band, y, x)` xarray DataArray from thousands of cloud-optimized geotiffs (COGs). No GDAL required.
+Open a lazy `(band, time, y, x)` xarray DataArray from thousands of cloud-optimized geotiffs (COGs). No GDAL required.
 
 ## What is lazycogs?
 
@@ -45,7 +45,7 @@ dst_crs = "EPSG:32615"
 dst_bbox = (380000.0, 4928000.0, 420000.0, 4984000.0)
 
 # transform to 4326 for STAC search
-transformer = Transformer.from_crs(dst_crs, "epsg:4326", alwaysxy=True)
+transformer = Transformer.from_crs(dst_crs, "epsg:4326", always_xy=True)
 bbox_4326 = transformer.transform_bounds(*dst_bbox)
 
 # Search a STAC API and cache results to a local stac-geoparquet file.
@@ -57,7 +57,7 @@ await rustac.search_to(
     bbox=bbox_4326,
 )
 
-# Open a fully lazy (time, band, y, x) DataArray. No COGs are read yet.
+# Open a fully lazy (band, time, y, x) DataArray. No COGs are read yet.
 da = lazycogs.open(
     "items.parquet",
     bbox=dst_bbox,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ![lazycogs](./lazycogs.svg)
 
-Open a lazy `(time, band, y, x)` xarray DataArray from thousands of cloud-optimized GeoTIFFs. No GDAL required.
+Open a lazy `(band, time, y, x)` xarray DataArray from thousands of cloud-optimized GeoTIFFs. No GDAL required.
 
 --8<-- "docs/includes/dataarray_repr.html"
 
@@ -50,7 +50,7 @@ await rustac.search_to(
     bbox=bbox_4326,
 )
 
-# Open a fully lazy (time, band, y, x) DataArray. No COGs are read yet.
+# Open a fully lazy (band, time, y, x) DataArray. No COGs are read yet.
 da = lazycogs.open(
     "items.parquet",
     bbox=dst_bbox,

--- a/src/lazycogs/_core.py
+++ b/src/lazycogs/_core.py
@@ -308,7 +308,7 @@ def _build_dataarray(
             :func:`open` for full documentation.
 
     Returns:
-        Lazy ``xr.DataArray`` with dimensions ``(time, band, y, x)``.
+        Lazy ``xr.DataArray`` with dimensions ``(band, time, y, x)``.
 
     """
     dst_affine, dst_width, dst_height, x_coords, y_coords = compute_output_grid(
@@ -386,7 +386,7 @@ def open(  # noqa: A001
     path_from_href: Callable[[str], str] | None = None,
     duckdb_client: DuckdbClient | None = None,
 ) -> xr.DataArray:
-    """Open a mosaic of STAC items as a lazy ``(time, band, y, x)`` DataArray.
+    """Open a mosaic of STAC items as a lazy ``(band, time, y, x)`` DataArray.
 
     ``href`` must be a path to a geoparquet file (``.parquet`` or
     ``.geoparquet``) or, when *duckdb_client* is provided, to a
@@ -480,7 +480,7 @@ def open(  # noqa: A001
                 )
 
     Returns:
-        Lazy ``xr.DataArray`` with dimensions ``(time, band, y, x)``.
+        Lazy ``xr.DataArray`` with dimensions ``(band, time, y, x)``.
 
     Raises:
         ValueError: If ``href`` is not a ``.parquet`` or ``.geoparquet`` file


### PR DESCRIPTION
resolves #35 by correctly describing dimension order as (band, time, y, x) in all docs.

Also fixes the bug in the basic example's pyproj Transformer args as described in #42 