### PR TITLE
fix: chunked nearest spatial selection with RasterIndex coordinates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,7 +49,7 @@ src/lazycogs/
 6. Calls `_build_time_steps()`: queries the parquet source via `duckdb_client.search_to_arrow(...)` to obtain an Arrow table containing only the `datetime` and `start_datetime` columns (plus any filter/sort fields). Extracts timestamps from the Arrow columns without Python-level dict walking, buckets them with the `_TemporalGrouper`, deduplicates, and returns sorted `(filter_strings, time_coords)` pairs. Only groups with at least one item produce a time step.
 7. Calls `compute_output_grid()` to get the output affine transform and dimensions (width, height). No eager coordinate arrays are produced.
 8. Creates a single `MultiBandStacBackendArray` (a dataclass) with shape `(band, time, y, x)` holding all the parameters needed to materialise any chunk later, then wraps it in one `xarray.core.indexing.LazilyIndexedArray`. This avoids `xr.concat` (used internally by `ds.to_array()`), which would eagerly load `LazilyIndexedArray`-backed objects.
-9. Uses `rasterix.RasterIndex` to define the x/y coordinates (lazily).
+9. Uses `rasterix.RasterIndex` for spatial indexing, but materialises the x/y coordinate variables eagerly as numpy arrays so chunked scalar spatial selections compute reliably.
 10. Constructs the `xr.DataArray` directly from the 4-D variable. If `chunks` is provided, calls `.chunk(chunks)` to convert to a dask-backed array; otherwise the `LazilyIndexedArray` remains in play so narrow slices (e.g. a single pixel) translate to minimal I/O.
 11. Stores `_stac_backend` (the `MultiBandStacBackendArray` instance) and `_stac_time_coords` (the full time coordinate array) in `da.attrs` so that `da.lazycogs.explain()` can reconstruct the explain plan without re-specifying `open()` parameters.
 
@@ -101,7 +101,7 @@ With `fetch_headers=True`, each matched COG header is fetched (a small HTTP rang
 
 The y coordinates are derived directly from the affine transform: `y[i] = f + e * (0.5 + i)`. Because `e < 0`, `y[0]` is the northernmost pixel centre and the array is strictly decreasing. Spatial selection uses `sel(y=slice(north, south))` (high to low).
 
-A `rasterix.RasterIndex` is attached to every DataArray returned by `open()`. The index replaces explicit x/y coordinate arrays with lazy coordinate generation from the affine transform, provides CRS discoverability via `da.proj.crs`, and enables spatial alignment with other RasterIndex-backed arrays.
+A `rasterix.RasterIndex` is attached to every DataArray returned by `open()`. The index provides CRS discoverability via `da.proj.crs` and enables spatial alignment with other RasterIndex-backed arrays. The x/y coordinate variables themselves are still materialised eagerly from that index so operations like `da.chunk(...).sel(x=..., y=..., method="nearest").compute()` keep scalar spatial coordinates as true scalars instead of length-1 arrays.
 
 ## Per-chunk read and resample pipeline
 
@@ -266,7 +266,7 @@ When the store root does not align with the URL structure of the asset HREFs —
 | `obstore` | Cloud object store abstraction layer for async-geotiff |
 | `pyproj` | CRS transforms: bbox reprojection, warp map generation |
 | `xarray` | DataArray / Dataset assembly, `BackendArray` / `LazilyIndexedArray` protocol |
-| `rasterix` | CRS-aware `RasterIndex` for lazy spatial coordinates |
+| `rasterix` | CRS-aware `RasterIndex` for spatial indexing and coordinate metadata |
 | `xproj` | CRS accessor and alignment for xarray Flexible Indexes |
 | `dask` | Parallel chunk execution |
 | `affine` | Affine transform arithmetic |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ GDAL.
 
 Use ``sel(y=slice(north, south))`` (high to low) for spatial subsetting.
 
+`x` and `y` keep their `RasterIndex`-based spatial selection behavior, but the
+coordinate variables themselves are materialized eagerly so chunked nearest-neighbor
+spatial selections compute cleanly.
+
 ## Example
 
 ```python

--- a/src/lazycogs/_core.py
+++ b/src/lazycogs/_core.py
@@ -251,6 +251,36 @@ def _build_time_steps(
     return filter_strings, time_coords
 
 
+def _spatial_coords_with_eager_variables(index: RasterIndex) -> Coordinates:
+    """Return RasterIndex-backed spatial coordinates with eager x/y variables.
+
+    ``Coordinates.from_xindex(index)`` keeps the x/y coordinate variables backed
+    by ``CoordinateTransformIndexingAdapter``. That works for normal access, but
+    after ``DataArray.chunk(...).sel(x=..., y=..., method="nearest")`` xarray can
+    end up computing scalar x/y coordinates as length-1 arrays, which then fail
+    shape validation during ``compute()``.
+
+    This helper keeps the ``RasterIndex`` itself for spatial selection semantics
+    while materialising the x/y coordinate variables as plain NumPy arrays so
+    scalar coordinate loads stay scalar after chunking.
+
+    Args:
+        index: Raster index describing the output grid.
+
+    Returns:
+        Coordinates containing eager x/y variables and the original RasterIndex.
+
+    """
+    index_variables = index.create_variables()
+    return Coordinates(
+        {
+            name: (variable.dims, np.asarray(variable.data), variable.attrs)
+            for name, variable in index_variables.items()
+        },
+        indexes=dict.fromkeys(index_variables, index),
+    )
+
+
 def _build_dataarray(
     *,
     parquet_path: str,
@@ -356,7 +386,7 @@ def _build_dataarray(
         y_dim="y",
         crs=dst_crs,
     )
-    spatial_coords = Coordinates.from_xindex(index)
+    spatial_coords = _spatial_coords_with_eager_variables(index)
 
     time_coord = np.array(time_coords, dtype="datetime64[D]")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import rustac
+from obstore.store import MemoryStore
 from rustac import DuckdbClient
 
 import lazycogs
@@ -283,17 +284,9 @@ def test_open_works_inside_running_event_loop(tmp_path):
     assert "error" not in result, f"Got RuntimeError: {result.get('error')}"
 
 
-def test_open_sets_expected_dataarray_attributes(tmp_path):
-    """open() attaches all expected extra attributes to the returned DataArray."""
-    from obstore.store import MemoryStore
-
-    parquet = tmp_path / "items.parquet"
-    parquet.write_bytes(b"")
-
-    store = MemoryStore()
-    store.put("B04.tif", b"dummy")
-
-    item = {
+def _fake_open_item() -> dict:
+    """Return a minimal STAC item used by open() tests."""
+    return {
         "id": "test-item",
         "stac_extensions": [],
         "properties": {"datetime": "2023-01-15T10:00:00Z"},
@@ -306,13 +299,24 @@ def test_open_sets_expected_dataarray_attributes(tmp_path):
         },
     }
 
+
+@pytest.fixture
+def opened_dataarray(tmp_path):
+    """Return a small DataArray from open() with DuckDB calls patched."""
+
+    parquet = tmp_path / "items.parquet"
+    parquet.write_bytes(b"")
+
+    store = MemoryStore()
+    store.put("B04.tif", b"dummy")
+
     table = _items_to_arrow([{"properties": {"datetime": "2023-01-15T10:00:00Z"}}])
 
     with (
-        patch("rustac.DuckdbClient.search", return_value=[item]),
+        patch("rustac.DuckdbClient.search", return_value=[_fake_open_item()]),
         patch("rustac.DuckdbClient.search_to_arrow", return_value=table),
     ):
-        da = lazycogs.open(
+        return lazycogs.open(
             str(parquet),
             bbox=(0.0, 0.0, 100.0, 100.0),
             crs="EPSG:32632",
@@ -320,6 +324,11 @@ def test_open_sets_expected_dataarray_attributes(tmp_path):
             store=store,
             path_from_href=lambda href: href.split("/", 3)[-1],
         )
+
+
+def test_open_sets_expected_dataarray_attributes(opened_dataarray):
+    """open() attaches all expected extra attributes to the returned DataArray."""
+    da = opened_dataarray
 
     # Coordinates
     assert da.coords["band"].values.tolist() == ["B04"]
@@ -353,6 +362,32 @@ def test_open_sets_expected_dataarray_attributes(tmp_path):
     assert da.attrs["_stac_time_coords"].dtype == np.dtype("datetime64[D]")
 
 
+def test_chunked_spatial_selection_computes_scalar_spatial_coords(opened_dataarray):
+    """Chunked nearest-neighbour spatial selection keeps x/y coords scalar."""
+    da = opened_dataarray
+
+    selected = da.chunk(time=1).sel(x=25.0, y=75.0, method="nearest")
+
+    x_coord = selected.coords["x"].compute()
+    y_coord = selected.coords["y"].compute()
+
+    assert x_coord.dims == ()
+    assert y_coord.dims == ()
+    assert x_coord.shape == ()
+    assert y_coord.shape == ()
+
+
+def test_chunked_spatial_selection_full_compute_succeeds(opened_dataarray):
+    """Chunked nearest-neighbour spatial selection can compute end-to-end."""
+    selected = opened_dataarray.chunk(time=1).sel(x=25.0, y=75.0, method="nearest")
+
+    with patch("rustac.DuckdbClient.search", return_value=[]):
+        computed = selected.compute()
+
+    assert computed.dims == ("band", "time")
+    assert computed.shape == (1, 1)
+
+
 # ---------------------------------------------------------------------------
 # _smoketest_store
 # ---------------------------------------------------------------------------
@@ -373,7 +408,6 @@ _SMOKETEST_ITEM = {
 
 def test_smoketest_passes_when_head_succeeds():
     """_smoketest_store does not raise when head() succeeds."""
-    from obstore.store import MemoryStore
 
     store = MemoryStore()
     store.put("B04.tif", b"dummy")
@@ -389,7 +423,6 @@ def test_smoketest_passes_when_head_succeeds():
 
 def test_smoketest_raises_runtime_error_on_head_failure():
     """_smoketest_store raises RuntimeError when the store cannot access the asset."""
-    from obstore.store import MemoryStore
 
     store = MemoryStore()  # empty — head() will raise
 
@@ -413,7 +446,6 @@ def test_smoketest_no_op_when_no_items():
 
 def test_smoketest_prefers_specified_band():
     """_smoketest_store uses the first specified band when bands= is given."""
-    from obstore.store import MemoryStore
 
     store = MemoryStore()
     store.put("B08.tif", b"dummy")


### PR DESCRIPTION
Fixes a shape mismatch when computing chunked nearest-neighbor spatial selections like da.chunk(time=1).sel(x=..., y=..., method="nearest").compute().

The bug came from lazy RasterIndex-backed scalar x/y coordinates materializing as length-1 arrays during compute. This change keeps the RasterIndex for spatial indexing, but materializes the x/y coordinate variables eagerly so scalar spatial coords compute correctly. Also adds regression tests and updates docs.

upstream issue: https://github.com/xarray-contrib/rasterix/issues/92
